### PR TITLE
Add a flash note before deleting a question

### DIFF
--- a/app/controllers/quiz_questionnaires_controller.rb
+++ b/app/controllers/quiz_questionnaires_controller.rb
@@ -231,6 +231,7 @@ class QuizQuestionnairesController < QuestionnairesController
       params[:question].each_key do |question_key|
         if params[:question][question_key][:txt].strip.empty?
           # question text is empty, delete the question
+          flash[:note] = "Question text is empty, so the question has been deleted"
           Question.delete(question_key)
         else
           # Update existing question.


### PR DESCRIPTION
Don't merge before we get clarification - the save_questions method code seems like it deletes a question if it's text is empty. 
When I test it though, it doesn't seem like this part of the method ever gets called/works. I can delete a question text/answer choice and nothing happens. The question is not deleted and I do not get a flashed message. 

Also, in quiz_questionnaires_controller_spec.rb, save_questions only gets called in one case and I think it just checks if the method can actually be called. There is nowhere to add the flash message expectation in the spec. 